### PR TITLE
Add netto/brutto price fields for options

### DIFF
--- a/admin/view/template/catalog/product_form.twig
+++ b/admin/view/template/catalog/product_form.twig
@@ -785,7 +785,16 @@
                                         {% endif %}
 
 
-                                      </select> <input type="text" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][price]" value="{{ product_option_value.price }}" placeholder="{{ entry_price }}" class="form-control"/></td>
+                                      </select>
+                                      <div class="input-group">
+                                        <span class="input-group-addon">{{ entry_price }} Brutto</span>
+                                        <input type="text" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][price_brutto]" value="{{ (product_option_value.price * (1 + tax_rate/100))|round(4) }}" class="form-control option-price-brutto"/>
+                                      </div>
+                                      <div class="input-group">
+                                        <span class="input-group-addon">{{ entry_price }} Netto</span>
+                                        <input type="text" name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][price]" value="{{ product_option_value.price }}" class="form-control option-price-netto"/>
+                                      </div>
+                                    </td>
                                     <td class="text-right"><select name="product_option[{{ option_row }}][product_option_value][{{ option_value_row }}][points_prefix]" class="form-control">
 
 
@@ -1502,11 +1511,23 @@ $('#article-related').delegate('.fa-minus-circle', 'click', function() {
 	});
   
   //AG brutto - netto
-  $('#input-price-brutto').on('keyup', function() { 
-		var th = $(this);
+  $('#input-price-brutto').on('keyup', function() {
+                var th = $(this);
     var tx = {{ tax_rate }} ;
     $('#input-price').val( (th.val() - ( th.val() * tx / ( 100 + tx ) )).toFixed(4) );
-	});
+        });
+
+  // option brutto-netto sync
+  $(document).on('keyup', '.option-price-brutto', function() {
+    var b = parseFloat($(this).val()) || 0;
+    var n = b * 100 / (100 + {{ tax_rate }});
+    $(this).closest('tr').find('.option-price-netto').val(n.toFixed(4));
+  });
+  $(document).on('keyup', '.option-price-netto', function() {
+    var n = parseFloat($(this).val()) || 0;
+    var b = n * (100 + {{ tax_rate }}) / 100;
+    $(this).closest('tr').find('.option-price-brutto').val(b.toFixed(4));
+  });
   
   //--></script>
   <script type="text/javascript"><!--
@@ -1666,11 +1687,18 @@ $('#article-related').delegate('.fa-minus-circle', 'click', function() {
 	  html += '    <option value="1">{{ text_yes }}</option>';
 	  html += '    <option value="0">{{ text_no }}</option>';
 	  html += '  </select></td>';
-	  html += '  <td class="text-right"><select name="product_option[' + option_row + '][product_option_value][' + option_value_row + '][price_prefix]" class="form-control">';
-	  html += '    <option value="+">+</option>';
-	  html += '    <option value="-">-</option>';
-	  html += '  </select>';
-	  html += '  <input type="text" name="product_option[' + option_row + '][product_option_value][' + option_value_row + '][price]" value="" placeholder="{{ entry_price }}" class="form-control" /></td>';
+          html += '  <td class="text-right"><select name="product_option[' + option_row + '][product_option_value][' + option_value_row + '][price_prefix]" class="form-control">';
+          html += '    <option value="+">+</option>';
+          html += '    <option value="-">-</option>';
+          html += '  </select>';
+          html += '  <div class="input-group">';
+          html += '    <span class="input-group-addon">{{ entry_price }} Brutto</span>';
+          html += '    <input type="text" name="product_option[' + option_row + '][product_option_value][' + option_value_row + '][price_brutto]" value="" class="form-control option-price-brutto" />';
+          html += '  </div>';
+          html += '  <div class="input-group">';
+          html += '    <span class="input-group-addon">{{ entry_price }} Netto</span>';
+          html += '    <input type="text" name="product_option[' + option_row + '][product_option_value][' + option_value_row + '][price]" value="" class="form-control option-price-netto" />';
+          html += '  </div></td>';
 	  html += '  <td class="text-right"><select name="product_option[' + option_row + '][product_option_value][' + option_value_row + '][points_prefix]" class="form-control">';
 	  html += '    <option value="+">+</option>';
 	  html += '    <option value="-">-</option>';


### PR DESCRIPTION
## Summary
- show netto and brutto fields for each option price
- sync those fields on keyup so editing one updates the other
- support same fields when dynamically adding new option values

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846781dce308320b4d67fb87ae0cc81