### PR TITLE
Fix discount module format and escape null strings

### DIFF
--- a/catalog/controller/extension/module/nr_mail_discount.php
+++ b/catalog/controller/extension/module/nr_mail_discount.php
@@ -13,7 +13,13 @@ class ControllerExtensionModuleNrMailDiscount extends Controller {
 		
 		$data['discount'] = (float)$data['coupon']['discount'].($data['coupon']['type'] == 'P' ? '%' : ' '.$this->session->data['currency']);
 		
-		$data['text'] = html_entity_decode(sprintf($this->config->get('module_nr_mail_discount_desc'), $data['discount']));
+               $desc = $this->config->get('module_nr_mail_discount_desc');
+
+               if (strpos($desc, '%s') !== false) {
+                       $data['text'] = html_entity_decode(sprintf($desc, $data['discount']));
+               } else {
+                       $data['text'] = html_entity_decode($desc);
+               }
 		
 		return $this->load->view('extension/module/nr_mail_discount', $data);
 	}

--- a/system/library/db/mysqli.php
+++ b/system/library/db/mysqli.php
@@ -42,9 +42,13 @@ final class MySQLi {
 		}
 	}
 
-	public function escape($value) {
-		return $this->connection->real_escape_string($value);
-	}
+       public function escape($value) {
+               if ($value === null) {
+                       $value = '';
+               }
+
+               return $this->connection->real_escape_string((string)$value);
+       }
 	
 	public function countAffected() {
 		return $this->connection->affected_rows;


### PR DESCRIPTION
## Summary
- prevent `mysqli::real_escape_string()` from receiving null
- avoid `sprintf` errors when discount text does not contain a `%s` placeholder

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fbdf50f4c8320af9cb34bd00cdade