### PR TITLE
Fix shipping address retrieval for logged-in users

### DIFF
--- a/catalog/controller/account/address.php
+++ b/catalog/controller/account/address.php
@@ -535,9 +535,22 @@ class ControllerAccountAddress extends Controller {
 		
                 if($address_id) {
                         $this->load->model('account/address');
-                        $data['address_info'] = $this->model_account_address->getAddress($address_id);
-                        $data['shipping'] = !empty($data['address_info']['custom_field']['shipping']) ? $data['address_info']['custom_field']['shipping'] : array();
-                        $data['recipient_same'] = isset($data['address_info']['custom_field']['recipient_same']) ? $data['address_info']['custom_field']['recipient_same'] : 1;
+                       $data['address_info'] = $this->model_account_address->getAddress($address_id);
+                       $cf = isset($data['address_info']['custom_field']) ? $data['address_info']['custom_field'] : array();
+                       if (!empty($cf['shipping'])) {
+                               $data['shipping'] = $cf['shipping'];
+                       } elseif (!empty($cf['address']['shipping'])) {
+                               $data['shipping'] = $cf['address']['shipping'];
+                       } else {
+                               $data['shipping'] = array();
+                       }
+                       if (isset($cf['recipient_same'])) {
+                               $data['recipient_same'] = $cf['recipient_same'];
+                       } elseif (isset($cf['address']['recipient_same'])) {
+                               $data['recipient_same'] = $cf['address']['recipient_same'];
+                       } else {
+                               $data['recipient_same'] = 1;
+                       }
                 } else {
                         $data['shipping'] = array();
                         $data['recipient_same'] = 1;

--- a/catalog/controller/checkout/buy.php
+++ b/catalog/controller/checkout/buy.php
@@ -77,8 +77,22 @@ class ControllerCheckoutBuy extends Controller
                         if ($data['logged']) {
                                 $data['buyer_address'] = $this->model_account_address->getAddress($this->customer->getAddressId());
                                 $data['buyer_address']['telephone'] = empty($data['buyer_address']['custom_field'][4]) ? '' : $data['buyer_address']['custom_field'][4];
-                                $saved_shipping = isset($data['buyer_address']['custom_field']['shipping']) ? $data['buyer_address']['custom_field']['shipping'] : array();
-                                $saved_recipient_same = isset($data['buyer_address']['custom_field']['recipient_same']) ? $data['buyer_address']['custom_field']['recipient_same'] : 1;
+                               $cf = isset($data['buyer_address']['custom_field']) ? $data['buyer_address']['custom_field'] : array();
+                               if (isset($cf['shipping'])) {
+                                       $saved_shipping = $cf['shipping'];
+                               } elseif (isset($cf['address']['shipping'])) {
+                                       $saved_shipping = $cf['address']['shipping'];
+                               } else {
+                                       $saved_shipping = array();
+                               }
+
+                               if (isset($cf['recipient_same'])) {
+                                       $saved_recipient_same = $cf['recipient_same'];
+                               } elseif (isset($cf['address']['recipient_same'])) {
+                                       $saved_recipient_same = $cf['address']['recipient_same'];
+                               } else {
+                                       $saved_recipient_same = 1;
+                               }
                         } else {
                                 $data['buyer_address'] = [
                                         'country_id' => $this->config->get('config_country_id'),


### PR DESCRIPTION
## Summary
- fix reading nested custom shipping fields for checkout
- handle nested custom shipping fields in account address form

## Testing
- `php -l catalog/controller/checkout/buy.php`
- `php -l catalog/controller/account/address.php`

------
https://chatgpt.com/codex/tasks/task_e_685948e0a58c8320808148dc1215d6a5