### PR TITLE
Fix buyer NIP field when user logged in

### DIFF
--- a/catalog/controller/checkout/buy.php
+++ b/catalog/controller/checkout/buy.php
@@ -77,6 +77,7 @@ class ControllerCheckoutBuy extends Controller
                         if ($data['logged']) {
                                 $data['buyer_address'] = $this->model_account_address->getAddress($this->customer->getAddressId());
                                 $data['buyer_address']['telephone'] = empty($data['buyer_address']['custom_field'][4]) ? '' : $data['buyer_address']['custom_field'][4];
+                                $data['buyer_address']['nip'] = isset($data['buyer_address']['custom_field'][2]) ? $data['buyer_address']['custom_field'][2] : '';
                                $cf = isset($data['buyer_address']['custom_field']) ? $data['buyer_address']['custom_field'] : array();
                                if (isset($cf['shipping'])) {
                                        $saved_shipping = $cf['shipping'];
@@ -99,13 +100,15 @@ class ControllerCheckoutBuy extends Controller
                                         'zone_id' => '',
                                         'address_id' => 0,
                                         'postcode' => '',
-                                        'city' => ''
+                                        'city' => '',
+                                        'nip' => ''
                                 ];
                         }
                         if ($data['logged']) {
                                 if (empty($data['buyer_address']['telephone'])) $data['buyer_address']['telephone'] = $this->customer->getTelephone();
                                 if (empty($data['buyer_address']['email'])) $data['buyer_address']['email'] = $this->customer->getEmail();
                                 if (empty($data['buyer_address']['company']) and !empty($custom_fields[1])) $data['buyer_address']['company'] = $custom_fields[1];
+                                if (empty($data['buyer_address']['nip']) and !empty($custom_fields[2])) $data['buyer_address']['nip'] = $custom_fields[2];
                         }
                 }
 

--- a/catalog/view/theme/noir/template/checkout/address.twig
+++ b/catalog/view/theme/noir/template/checkout/address.twig
@@ -31,15 +31,13 @@
 		<input type="text" name="buyer[email]" value="{{ buyer_address.email }}" placeholder="{{ entry_email_address }}"/>
 		<div class="form-error"></div>
 	</div>
-	{% if not logged %}
-		<div class="form-block">
-			<input type="text" name="buyer[company]" value="{{ buyer_address.company }}" placeholder="{{ entry_company }}" class="form-control"/>
-		</div>
-		<div class="form-block df aic">
-			<input type="text" name="buyer[nip]" id="input-nip" value="{{ buyer_address.nip }}" placeholder="NIP" class="form-control"/>
-			<button type="button" class="btn" id="btn-nip" disabled>Sprawdź</button>
-		</div>
-	{% endif %}
+        <div class="form-block">
+                <input type="text" name="buyer[company]" value="{{ buyer_address.company }}" placeholder="{{ entry_company }}" class="form-control"/>
+        </div>
+        <div class="form-block df aic">
+                <input type="text" name="buyer[nip]" id="input-nip" value="{{ buyer_address.nip }}" placeholder="NIP" class="form-control"/>
+                <button type="button" class="btn" id="btn-nip" disabled>Sprawdź</button>
+        </div>
 </div>
 <div class="form-block">
 	<label class="checkbox large-box df small-text">


### PR DESCRIPTION
## Summary
- load buyer NIP from address custom fields
- default buyer address now includes `nip`
- expose company and NIP fields for all customers in checkout

## Testing
- `php -l catalog/controller/checkout/buy.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594eb24374832097e6e63289f867dc