### PR TITLE
Improve address loading logic

### DIFF
--- a/catalog/controller/checkout/buy.php
+++ b/catalog/controller/checkout/buy.php
@@ -71,9 +71,31 @@ class ControllerCheckoutBuy extends Controller
 			$data['address_id'] = $this->customer->getAddressId();
 		}
 
-                if (isset($this->session->data['payment_address'])) {
-                        $data['buyer_address'] = $this->session->data['payment_address'];
-                } else {
+               if (isset($this->session->data['payment_address'])) {
+                       $data['buyer_address'] = $this->session->data['payment_address'];
+                       $saved_shipping = array();
+                       $saved_recipient_same = 1;
+                       if ($data['logged']) {
+                               $current_address = $this->model_account_address->getAddress($this->customer->getAddressId());
+                               $cf = isset($current_address['custom_field']) ? $current_address['custom_field'] : array();
+                               if (isset($cf['shipping'])) {
+                                       $saved_shipping = $cf['shipping'];
+                               } elseif (isset($cf['address']['shipping'])) {
+                                       $saved_shipping = $cf['address']['shipping'];
+                               }
+
+                               if (isset($cf['recipient_same'])) {
+                                       $saved_recipient_same = $cf['recipient_same'];
+                               } elseif (isset($cf['address']['recipient_same'])) {
+                                       $saved_recipient_same = $cf['address']['recipient_same'];
+                               }
+
+                               if (empty($data['buyer_address']['telephone'])) $data['buyer_address']['telephone'] = $this->customer->getTelephone();
+                               if (empty($data['buyer_address']['email'])) $data['buyer_address']['email'] = $this->customer->getEmail();
+                               if (empty($data['buyer_address']['company']) && !empty($custom_fields[1])) $data['buyer_address']['company'] = $custom_fields[1];
+                               if (empty($data['buyer_address']['nip']) && !empty($custom_fields[2])) $data['buyer_address']['nip'] = $custom_fields[2];
+                       }
+               } else {
                         if ($data['logged']) {
                                 $data['buyer_address'] = $this->model_account_address->getAddress($this->customer->getAddressId());
                                 $data['buyer_address']['telephone'] = empty($data['buyer_address']['custom_field'][4]) ? '' : $data['buyer_address']['custom_field'][4];


### PR DESCRIPTION
## Summary
- revert previous recipient_same column changes
- load buyer and recipient address details from stored data

## Testing
- `php -l catalog/controller/checkout/buy.php`

------
https://chatgpt.com/codex/tasks/task_e_685a369204b48320b60760f98dc66ed5