### PR TITLE
Fix checkout address country ID field

### DIFF
--- a/catalog/view/theme/noir/template/checkout/address.twig
+++ b/catalog/view/theme/noir/template/checkout/address.twig
@@ -125,7 +125,7 @@
 <div style="background:#fff; max-width:400px; margin:100px auto; padding:20px; position:relative; border-radius:6px; box-shadow:0 2px 10px rgba(0,0,0,0.3);">
 	<button id="nip-modal-close" type="button" style="position:absolute; top:10px; right:10px; background:none; border:none; font-size:18px; cursor:pointer;">&times;</button>
 	<div id="nip-modal-text" style="font-size:15px; line-height:1.5;"></div>
-</div></div><input type="hidden" name="buyer[country_id]" value="{{ buyer_address.country_id }}"><inputtype="hidden" name="address[country_id]" value="{{ shipping_address.country_id }}"> <script>
+</div></div><input type="hidden" name="buyer[country_id]" value="{{ buyer_address.country_id }}"><input type="hidden" name="address[country_id]" value="{{ shipping_address.country_id }}"> <script>
 	    (function(){
 	        var chkSame = document.getElementById('recipient_same');
 	        var block = document.getElementById('recipient-block');


### PR DESCRIPTION
## Summary
- restore original shipping and payment models
- correct hidden `address[country_id]` input markup

## Testing
- `php -l catalog/model/extension/payment/bank_transfer.php`
- `php -l catalog/model/extension/payment/cod.php`
- `php -l catalog/model/extension/payment/payu.php`
- `php -l catalog/model/extension/shipping/dpd.php`
- `php -l catalog/model/extension/shipping/inpost.php`
- `php -l catalog/model/extension/shipping/upsl.php`


------
https://chatgpt.com/codex/tasks/task_e_685ba14e2f6c832081e995647143f906