### PR TITLE
Ensure address fields present for checkout quoting

### DIFF
--- a/catalog/controller/checkout/buy.php
+++ b/catalog/controller/checkout/buy.php
@@ -342,17 +342,25 @@ class ControllerCheckoutBuy extends Controller
 
 	protected function updateShippingMethods()
 	{
-		$method_data = array();
-		$this->load->model('setting/extension');
+                $method_data = array();
+                $this->load->model('setting/extension');
 
-		$results = $this->model_setting_extension->getExtensions('shipping');
-		foreach ($results as $result) {
-			if ($this->config->get('shipping_' . $result['code'] . '_status')) {
-				$this->load->model('extension/shipping/' . $result['code']);
-				$quote = $this->{'model_extension_shipping_' . $result['code']}->getQuote($this->session->data['shipping_address']);
-				if ($quote) $method_data[$result['code']] = $quote;
-			}
-		}
+                $address = $this->session->data['shipping_address'] ?? [];
+                $address += [
+                        'country_id' => 0,
+                        'zone_id'    => 0,
+                        'city'       => '',
+                        'postcode'   => ''
+                ];
+
+                $results = $this->model_setting_extension->getExtensions('shipping');
+                foreach ($results as $result) {
+                        if ($this->config->get('shipping_' . $result['code'] . '_status')) {
+                                $this->load->model('extension/shipping/' . $result['code']);
+                                $quote = $this->{'model_extension_shipping_' . $result['code']}->getQuote($address);
+                                if ($quote) $method_data[$result['code']] = $quote;
+                        }
+                }
 
 		$sort_order = array();
 		foreach ($method_data as $key => $value) {
@@ -388,16 +396,22 @@ class ControllerCheckoutBuy extends Controller
 
 	protected function updatePaymentMethods()
 	{
-		$method_data = array();
-		$total = $this->cart->getSubTotal();
-		$this->load->model('setting/extension');
-		$recurring = $this->cart->hasRecurringProducts();
+                $method_data = array();
+                $total = $this->cart->getSubTotal();
+                $this->load->model('setting/extension');
+                $recurring = $this->cart->hasRecurringProducts();
 
-		$results = $this->model_setting_extension->getExtensions('payment');
-		foreach ($results as $result) {
-			if ($this->config->get('payment_' . $result['code'] . '_status')) {
-				$this->load->model('extension/payment/' . $result['code']);
-				$method = $this->{'model_extension_payment_' . $result['code']}->getMethod($this->session->data['shipping_address'], $total);
+                $address = $this->session->data['shipping_address'] ?? [];
+                $address += [
+                        'country_id' => 0,
+                        'zone_id'    => 0
+                ];
+
+                $results = $this->model_setting_extension->getExtensions('payment');
+                foreach ($results as $result) {
+                        if ($this->config->get('payment_' . $result['code'] . '_status')) {
+                                $this->load->model('extension/payment/' . $result['code']);
+                                $method = $this->{'model_extension_payment_' . $result['code']}->getMethod($address, $total);
 				if ($method) {
 
 					$image_path = DIR_IMAGE . 'payment/' . $result['code'] . '.png';

--- a/catalog/view/theme/noir/template/checkout/address.twig
+++ b/catalog/view/theme/noir/template/checkout/address.twig
@@ -125,7 +125,7 @@
 <div style="background:#fff; max-width:400px; margin:100px auto; padding:20px; position:relative; border-radius:6px; box-shadow:0 2px 10px rgba(0,0,0,0.3);">
 	<button id="nip-modal-close" type="button" style="position:absolute; top:10px; right:10px; background:none; border:none; font-size:18px; cursor:pointer;">&times;</button>
 	<div id="nip-modal-text" style="font-size:15px; line-height:1.5;"></div>
-</div></div><input type="hidden" name="buyer[country_id]" value="{{ buyer_address.country_id }}"><inputtype="hidden" name="address[country_id]" value="{{ shipping_address.country_id }}"> <script>
+</div></div><input type="hidden" name="buyer[country_id]" value="{{ buyer_address.country_id }}"><input type="hidden" name="address[country_id]" value="{{ shipping_address.country_id }}"> <script>
 	    (function(){
 	        var chkSame = document.getElementById('recipient_same');
 	        var block = document.getElementById('recipient-block');


### PR DESCRIPTION
## Summary
- guarantee `country_id`, `zone_id`, and other keys when invoking shipping and payment models

## Testing
- `php -l catalog/controller/checkout/buy.php`
- `php -l catalog/model/extension/payment/bank_transfer.php`
- `php -l catalog/model/extension/payment/cod.php`
- `php -l catalog/model/extension/payment/payu.php`
- `php -l catalog/model/extension/shipping/dpd.php`
- `php -l catalog/model/extension/shipping/inpost.php`
- `php -l catalog/model/extension/shipping/upsl.php`

------
https://chatgpt.com/codex/tasks/task_e_685ba14e2f6c832081e995647143f906