### PR TITLE
Fix shipping address saving

### DIFF
--- a/catalog/controller/checkout/buy.php
+++ b/catalog/controller/checkout/buy.php
@@ -568,12 +568,13 @@ class ControllerCheckoutBuy extends Controller
                         $order_data['payment_city'] = $buyer['city'];
                         $order_data['payment_postcode'] = $buyer['postcode'];
 			//$order_data['payment_zone'] = $zone_info['name'];
-			$order_data['payment_zone'] = '';
+                        $zone_info = $this->model_localisation_zone->getZone($buyer['zone_id']);
+                        $order_data['payment_zone'] = $zone_info ? $zone_info['name'] : '';
                         $order_data['payment_zone_id'] = $buyer['zone_id'];
                         $order_data['payment_country'] = $country_info['name'];
                         $order_data['payment_country_id'] = $buyer['country_id'];
-			$order_data['payment_address_format'] = '';
-			$order_data['payment_custom_field'] = [];
+                        $order_data['payment_address_format'] = $country_info['address_format'];
+                        $order_data['payment_custom_field'] = [];
 
                         $order_data['shipping_firstname'] = $address['firstname'];
                         $order_data['shipping_lastname'] = $address['lastname'];
@@ -582,12 +583,16 @@ class ControllerCheckoutBuy extends Controller
                         $order_data['shipping_address_2'] = $order_data['payment_address_2'];
                         $order_data['shipping_city'] = $address['city'];
                         $order_data['shipping_postcode'] = $address['postcode'];
-                        $order_data['shipping_zone'] = $order_data['payment_zone'];
+
+                        $shipping_zone_info = $this->model_localisation_zone->getZone($address['zone_id']);
+                        $order_data['shipping_zone'] = $shipping_zone_info ? $shipping_zone_info['name'] : '';
                         $order_data['shipping_zone_id'] = $address['zone_id'];
-                        $order_data['shipping_country'] = $order_data['payment_country'];
+
+                        $shipping_country_info = $this->model_localisation_country->getCountry($address['country_id']);
+                        $order_data['shipping_country'] = $shipping_country_info ? $shipping_country_info['name'] : '';
                         $order_data['shipping_country_id'] = $address['country_id'];
-			$order_data['shipping_address_format'] = $order_data['payment_address_format'];
-			$order_data['shipping_custom_field'] = $order_data['payment_custom_field'];
+                        $order_data['shipping_address_format'] = $shipping_country_info ? $shipping_country_info['address_format'] : '';
+                        $order_data['shipping_custom_field'] = isset($address['custom_field']) ? $address['custom_field'] : [];
 
 			if (isset($this->session->data['shipping_method']['title'])) {
 				$order_data['shipping_method'] = $this->session->data['shipping_method']['title'];


### PR DESCRIPTION
## Summary
- ensure shipping zone and country data is looked up from recipient address
- store correct recipient address formatting when saving orders

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685bab785ff08320a0cb4534d937e876