### PR TITLE
Add Polish post-action modal messages

### DIFF
--- a/catalog/view/theme/noir/js/template.js
+++ b/catalog/view/theme/noir/js/template.js
@@ -99,18 +99,23 @@ function register() {
 		type: 'post',
 		dataType: 'json',
 		data: m.find('form').serialize(),
-		success: function(json) {
-			checkJson(json);
-			if(json.error) {
-				$.each(json.error, function(i, v){
-					if(v == 1) {
-						m.find('[data-error="'+i+'"]').addClass('input-error');
-					} else {
-						m.find('[data-error="'+i+'"]').addClass('input-error').find('.form-error').text(v).show();
-					}
-				});
-			}
-		},
+                success: function(json) {
+                        if(json.error) {
+                                $.each(json.error, function(i, v){
+                                        if(v == 1) {
+                                                m.find('[data-error="'+i+'"]').addClass('input-error');
+                                        } else {
+                                                m.find('[data-error="'+i+'"]').addClass('input-error').find('.form-error').text(v).show();
+                                        }
+                                });
+                        } else if(json.redirect == 1) {
+                                show_modal_message('Sprawdź swoją skrzynkę e-mail oraz folder SPAM.', function(){
+                                        location.reload();
+                                });
+                        } else {
+                                checkJson(json);
+                        }
+                },
 		error: function(data) {console.log(data.responseText);}
 	});
 }
@@ -657,13 +662,16 @@ $(document).on('click', '.product-item-btn-option', function() {
   cart.add(data);
 });
 
-function show_modal_message(text) {
-	const content = document.getElementById('popup-message-content');
-	if (content) {
-		content.innerHTML = text;
-		$.fancybox.open({
-			src: '#popup-message',
-			type: 'inline'
-		});
-	}
+function show_modal_message(text, callback) {
+        const content = document.getElementById('popup-message-content');
+        if (content) {
+                content.innerHTML = text;
+                $.fancybox.open({
+                        src: '#popup-message',
+                        type: 'inline',
+                        afterClose: callback
+                });
+        } else if (typeof callback === 'function') {
+                callback();
+        }
 }

--- a/catalog/view/theme/noir/template/common/success.twig
+++ b/catalog/view/theme/noir/template/common/success.twig
@@ -27,4 +27,6 @@
 	{{ column_left }}
 	{{ column_right }}
 </div>
-{{ footer }}</body></html>
+{{ footer }}
+<script>show_modal_message('Sprawdź swoją skrzynkę e-mail oraz folder SPAM.');</script>
+</body></html>


### PR DESCRIPTION
## Summary
- expand `show_modal_message` to accept callback
- show modal after successful registration
- trigger modal with Polish notice on order success page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f7df5abb48320be249771b8cee4ea