### PR TITLE
Add city-aware virtual routes for categories

### DIFF
--- a/catalog/controller/extension/feed/google_sitemap.php
+++ b/catalog/controller/extension/feed/google_sitemap.php
@@ -26,9 +26,17 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 				}
 			}
 
-			$this->load->model('catalog/category');
+                        $this->load->model('catalog/category');
+                        $this->load->model('localisation/city');
 
-			$output .= $this->getCategories(0);
+                        // default category links
+                        $output .= $this->getCategories(0);
+
+                        // category links with city prefix
+                        $cities = $this->model_localisation_city->getCities();
+                        foreach ($cities as $city) {
+                                $output .= $this->getCategories(0, '', $city['city_id']);
+                        }
 
 			$this->load->model('catalog/manufacturer');
 
@@ -71,37 +79,37 @@ class ControllerExtensionFeedGoogleSitemap extends Controller {
 		}
 	}
 
-	protected function getCategories($parent_id, $current_path = '') {
-		$output = '';
+        protected function getCategories($parent_id, $current_path = '', $city_id = 0) {
+                $output = '';
 
-		$results = $this->model_catalog_category->getCategories($parent_id);
+                $results = $this->model_catalog_category->getCategories($parent_id);
 
-		foreach ($results as $result) {
-			if (!$current_path) {
-				$new_path = $result['category_id'];
-			} else {
-				$new_path = $current_path . '_' . $result['category_id'];
-			}
+                foreach ($results as $result) {
+                        if (!$current_path) {
+                                $new_path = $result['category_id'];
+                        } else {
+                                $new_path = $current_path . '_' . $result['category_id'];
+                        }
 
-			$output .= '<url>';
-			$output .= '  <loc>' . $this->url->link('product/category', 'path=' . $new_path) . '</loc>';
-			$output .= '  <changefreq>weekly</changefreq>';
-			$output .= '  <priority>0.7</priority>';
-			$output .= '</url>';
+                        $output .= '<url>';
+                        $output .= '  <loc>' . $this->url->link('product/category', 'path=' . $new_path . ($city_id ? '&city_id=' . $city_id : '')) . '</loc>';
+                        $output .= '  <changefreq>weekly</changefreq>';
+                        $output .= '  <priority>0.7</priority>';
+                        $output .= '</url>';
 
-			$products = $this->model_catalog_product->getProducts(array('filter_category_id' => $result['category_id']));
+                        $products = $this->model_catalog_product->getProducts(array('filter_category_id' => $result['category_id']));
 
-			foreach ($products as $product) {
-				$output .= '<url>';
-				$output .= '  <loc>' . $this->url->link('product/product', 'path=' . $new_path . '&product_id=' . $product['product_id']) . '</loc>';
-				$output .= '  <changefreq>weekly</changefreq>';
-				$output .= '  <priority>1.0</priority>';
-				$output .= '</url>';
-			}
+                        foreach ($products as $product) {
+                                $output .= '<url>';
+                                $output .= '  <loc>' . $this->url->link('product/product', 'path=' . $new_path . '&product_id=' . $product['product_id'] . ($city_id ? '&city_id=' . $city_id : '')) . '</loc>';
+                                $output .= '  <changefreq>weekly</changefreq>';
+                                $output .= '  <priority>1.0</priority>';
+                                $output .= '</url>';
+                        }
 
-			$output .= $this->getCategories($result['category_id'], $new_path);
-		}
+                        $output .= $this->getCategories($result['category_id'], $new_path, $city_id);
+                }
 
-		return $output;
-	}
+                return $output;
+        }
 }

--- a/catalog/controller/extension/feed/nn_google_sitemap.php
+++ b/catalog/controller/extension/feed/nn_google_sitemap.php
@@ -54,8 +54,14 @@ class ControllerExtensionFeedNNGoogleSitemap extends Controller {
 
     if (!empty($catalogs) && in_array('category', $catalogs) || !isset($catalogs)) {
       $this->load->model('catalog/category');
+      $this->load->model('localisation/city');
 
       $output .= $this->getCategories(0);
+
+      $cities = $this->model_localisation_city->getCities();
+      foreach ($cities as $city) {
+        $output .= $this->getCategories(0, $city['city_id']);
+      }
     }
 
     if (!empty($catalogs) && in_array('manufacturer', $catalogs) || !isset($catalogs)) {
@@ -93,21 +99,21 @@ class ControllerExtensionFeedNNGoogleSitemap extends Controller {
     $this->response->setOutput($output);
 	}
 
-	protected function getCategories($parent_id) {
-		$output = '';
+        protected function getCategories($parent_id, $city_id = 0) {
+                $output = '';
 
-		$results = $this->model_catalog_category->getCategories($parent_id);
+                $results = $this->model_catalog_category->getCategories($parent_id);
 
-		foreach ($results as $result) {
-			$output .= '<url>';
-			$output .= '  <loc>' . $this->url->link('product/category', 'path=' . $result['category_id']) . '</loc>';
-			$output .= '  <changefreq>weekly</changefreq>';
-			$output .= '  <priority>0.7</priority>';
-			$output .= '</url>';
+                foreach ($results as $result) {
+                        $output .= '<url>';
+                        $output .= '  <loc>' . $this->url->link('product/category', 'path=' . $result['category_id'] . ($city_id ? '&city_id=' . $city_id : '')) . '</loc>';
+                        $output .= '  <changefreq>weekly</changefreq>';
+                        $output .= '  <priority>0.7</priority>';
+                        $output .= '</url>';
 
-			$output .= $this->getCategories($result['category_id']);
-		}
+                        $output .= $this->getCategories($result['category_id'], $city_id);
+                }
 
-		return $output;
-	}
+                return $output;
+        }
 }

--- a/catalog/controller/startup/seo_url.php
+++ b/catalog/controller/startup/seo_url.php
@@ -20,19 +20,29 @@ class ControllerStartupSeoUrl extends Controller {
 		}
 	
 		// Decode URL
-		if (isset($this->request->get['_route_'])) {
-			$parts = explode('/', $this->request->get['_route_']);
-			
-		//seopro prepare route
-		if($this->config->get('config_seo_pro')){		
-			$parts = $this->seo_pro->prepareRoute($parts);
-		}
-		//seopro prepare route end
+                if (isset($this->request->get['_route_'])) {
+                        $parts = explode('/', $this->request->get['_route_']);
 
-			// remove any empty arrays from trailing
-			if (utf8_strlen(end($parts)) == 0) {
-				array_pop($parts);
-			}
+                        // detect city keyword in first part
+                        $this->load->model('localisation/city');
+                        if (!empty($parts[0])) {
+                                $city_info = $this->model_localisation_city->getCityByKeyword($parts[0]);
+                                if ($city_info) {
+                                        $this->request->get['city_id'] = $city_info['city_id'];
+                                        array_shift($parts);
+                                }
+                        }
+
+                //seopro prepare route
+                if($this->config->get('config_seo_pro')){
+                        $parts = $this->seo_pro->prepareRoute($parts);
+                }
+                //seopro prepare route end
+
+                        // remove any empty arrays from trailing
+                        if ($parts && utf8_strlen(end($parts)) == 0) {
+                                array_pop($parts);
+                        }
 	
 			foreach ($parts as $part) {
 				$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "seo_url WHERE keyword = '" . $this->db->escape($part) . "' AND store_id = '" . (int)$this->config->get('config_store_id') . "'");
@@ -106,17 +116,23 @@ class ControllerStartupSeoUrl extends Controller {
 
 		parse_str($url_info['query'], $data);
 		
-		//seo_pro baseRewrite
-		if($this->config->get('config_seo_pro')){		
-			list($url, $data, $postfix) =  $this->seo_pro->baseRewrite($data, (int)$this->config->get('config_language_id'));	
-		}
-		
-		
+                //seo_pro baseRewrite
+                if($this->config->get('config_seo_pro')){
+                        list($url, $data, $postfix) =  $this->seo_pro->baseRewrite($data, (int)$this->config->get('config_language_id'));
+                }
 
-		
-		//seo_pro baseRewrite
+                // add city keyword to url if present
+                if (isset($data['city_id'])) {
+                        $query = $this->db->query("SELECT keyword FROM " . DB_PREFIX . "city WHERE city_id = '" . (int)$data['city_id'] . "'");
+                        if ($query->num_rows && $query->row['keyword']) {
+                                $url .= '/' . $query->row['keyword'];
+                        }
+                        unset($data['city_id']);
+                }
 
-		foreach ($data as $key => $value) {
+                //seo_pro baseRewrite
+
+                foreach ($data as $key => $value) {
 			if (isset($data['route'])) {
 				if (($data['route'] == 'product/product' && $key == 'product_id') || (($data['route'] == 'product/manufacturer/info' || $data['route'] == 'product/product') && $key == 'manufacturer_id') || ($data['route'] == 'information/information' && $key == 'information_id')) {
 					$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "seo_url WHERE `query` = '" . $this->db->escape($key . '=' . (int)$value) . "' AND store_id = '" . (int)$this->config->get('config_store_id') . "' AND language_id = '" . (int)$this->config->get('config_language_id') . "'");

--- a/catalog/model/localisation/city.php
+++ b/catalog/model/localisation/city.php
@@ -1,0 +1,17 @@
+<?php
+class ModelLocalisationCity extends Model {
+    public function getCity($city_id) {
+        $query = $this->db->query("SELECT * FROM " . DB_PREFIX . "city WHERE city_id = '" . (int)$city_id . "'");
+        return $query->row;
+    }
+
+    public function getCityByKeyword($keyword) {
+        $query = $this->db->query("SELECT * FROM " . DB_PREFIX . "city WHERE keyword = '" . $this->db->escape($keyword) . "'");
+        return $query->row;
+    }
+
+    public function getCities() {
+        $query = $this->db->query("SELECT * FROM " . DB_PREFIX . "city ORDER BY name ASC");
+        return $query->rows;
+    }
+}


### PR DESCRIPTION
## Summary
- support optional city prefix in SEO URLs and link rewriting
- expose sitemap entries for each category in every city
- add model for managing city keywords in the database

## Testing
- `php -l catalog/model/localisation/city.php`
- `php -l catalog/controller/startup/seo_url.php`
- `php -l catalog/controller/extension/feed/google_sitemap.php`
- `php -l catalog/controller/extension/feed/nn_google_sitemap.php`


------
https://chatgpt.com/codex/tasks/task_e_689342f5a3dc83208f460d9cb0c3bba4