### PR TITLE
Include city id in category canonical links

### DIFF
--- a/catalog/controller/product/category.php
+++ b/catalog/controller/product/category.php
@@ -461,18 +461,20 @@ class ControllerProductCategory extends Controller {
 
 			$data['results'] = sprintf($this->language->get('text_pagination'), ($product_total) ? (($page - 1) * $limit) + 1 : 0, ((($page - 1) * $limit) > ($product_total - $limit)) ? $product_total : ((($page - 1) * $limit) + $limit), $product_total, ceil($product_total / $limit));
 
+            $city_param = isset($this->request->get['city_id']) ? '&city_id=' . (int)$this->request->get['city_id'] : '';
+
             if (!$this->config->get('config_canonical_method')) {
                 // http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
                 if ($page == 1) {
-                    $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id']), 'canonical');
+                    $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . $city_param), 'canonical');
                 } elseif ($page == 2) {
-                    $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id']), 'prev');
+                    $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . $city_param), 'prev');
                 } else {
-                    $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . '&page=' . ($page - 1)), 'prev');
+                    $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . '&page=' . ($page - 1) . $city_param), 'prev');
                 }
 
                 if ($limit && ceil($product_total / $limit) > $page) {
-                    $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . '&page=' . ($page + 1)), 'next');
+                    $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . '&page=' . ($page + 1) . $city_param), 'next');
                 }
             } else {
 
@@ -483,7 +485,7 @@ class ControllerProductCategory extends Controller {
                 };
 
                 $request_url = rtrim($server, '/') . $this->request->server['REQUEST_URI'];
-                $canonical_url = $this->url->link('product/category', 'path=' . $category_info['category_id']);
+                $canonical_url = $this->url->link('product/category', 'path=' . $category_info['category_id'] . $city_param);
 
                 if (($request_url != $canonical_url) || $this->config->get('config_canonical_self')) {
                     $this->document->addLink($canonical_url, 'canonical');
@@ -492,13 +494,13 @@ class ControllerProductCategory extends Controller {
                 if ($this->config->get('config_add_prevnext')) {
 
                     if ($page == 2) {
-                        $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id']), 'prev');
+                        $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . $city_param), 'prev');
                     } elseif ($page > 2)  {
-                        $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . '&page=' . ($page - 1)), 'prev');
+                        $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . '&page=' . ($page - 1) . $city_param), 'prev');
                     }
 
                     if ($limit && ceil($product_total / $limit) > $page) {
-                        $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . '&page=' . ($page + 1)), 'next');
+                        $this->document->addLink($this->url->link('product/category', 'path=' . $category_info['category_id'] . '&page=' . ($page + 1) . $city_param), 'next');
                     }
                 }
             }

--- a/catalog/controller/startup/seo_url.php
+++ b/catalog/controller/startup/seo_url.php
@@ -121,14 +121,15 @@ class ControllerStartupSeoUrl extends Controller {
                         list($url, $data, $postfix) =  $this->seo_pro->baseRewrite($data, (int)$this->config->get('config_language_id'));
                 }
 
-                // add city keyword to url if present
-                if (isset($data['city_id'])) {
-                        $query = $this->db->query("SELECT keyword FROM " . DB_PREFIX . "city WHERE city_id = '" . (int)$data['city_id'] . "'");
+                // add city keyword to url if present in data or request
+                $city_id = isset($data['city_id']) ? (int)$data['city_id'] : (isset($this->request->get['city_id']) ? (int)$this->request->get['city_id'] : 0);
+                if ($city_id) {
+                        $query = $this->db->query("SELECT keyword FROM " . DB_PREFIX . "city WHERE city_id = '" . (int)$city_id . "'");
                         if ($query->num_rows && $query->row['keyword']) {
                                 $url .= '/' . $query->row['keyword'];
                         }
-                        unset($data['city_id']);
                 }
+                unset($data['city_id']);
 
                 //seo_pro baseRewrite
 


### PR DESCRIPTION
## Summary
- Append current `city_id` to category canonical, prev, and next links for accurate city-specific URLs.
- Enhance SEO URL rewriting to obtain `city_id` from either link parameters or the current request.

## Testing
- `php -l catalog/controller/product/category.php`
- `php -l catalog/controller/startup/seo_url.php`


------
https://chatgpt.com/codex/tasks/task_e_6893496c801c83208c2ea54551dc7912